### PR TITLE
Remove tempfile lock before continuing analysis

### DIFF
--- a/auto_ghidra.py
+++ b/auto_ghidra.py
@@ -23,6 +23,7 @@ def uniquify(path, sep = ''):
         dirname, basename = os.path.split(path)
         filename, ext = os.path.splitext(basename)
         fd, filename = tempfile.mkstemp(dir = dirname, prefix = filename, suffix = ext)
+        os.remove(filename)
         tempfile._name_sequence = orig
     return filename
 


### PR DESCRIPTION
This fixes #17 that I also ran into. This is just a copied patch from the original repo where it was also added by the original author.

Without this line, ghidra fails to open the project to analyze anything and just makes a mess in the directory.

With this line, it analyzes properly and makes no mess.

Thanks for the excellent videos!